### PR TITLE
xxdrp & calculate_hash fixes

### DIFF
--- a/mediacrush
+++ b/mediacrush
@@ -85,16 +85,14 @@ while true; do
 done
 
 xxdrp() {
-	i=0;
-	while [ $i -lt ${#1} ]; do
-		echo -ne "\x${1:$i:2}";
-		let i+=2;
+	for i in `fold -2`; do
+		echo -ne "\x${i}";
 	done;
 }
 
 
 calculate_hash() {
-    md5sum $1 | xxdrp | base64 | cut -d " " -f 1 | tr "+/" "-_" | cut -c 1-12
+    md5sum $1 | cut -d " " -f 1 | xxdrp | base64 | tr "+/" "-_" | cut -c 1-12
 }
 
 upload() {


### PR DESCRIPTION
It was little mistake in previous xxdrp realization. Now it works fine and optimized (using coreutils power).

Also `cut -d " " -f 1` in calculate_hash() should be few pipes earlier.

Now it looks like a charm :D
